### PR TITLE
Add a call command to contact an agent that is running as a server

### DIFF
--- a/cmd/netorcai/main.go
+++ b/cmd/netorcai/main.go
@@ -206,7 +206,7 @@ Options:
 		interactivePrompt = terminal.IsTerminal(int(os.Stdout.Fd()))
 	}
 
-	go netorcai.RunPrompt(globalState, shellExit, interactivePrompt)
+	go netorcai.RunPrompt(globalState, shellExit, gameLogicExit, interactivePrompt)
 
 	select {
 	case serverExitCode := <-serverExit:

--- a/network.go
+++ b/network.go
@@ -163,3 +163,22 @@ func sendMessage(client *Client, content []byte) error {
 	client.writer.Flush()
 	return nil
 }
+
+func callAgent(url string, globalState *GlobalState, gameLogicExit chan int) {
+
+	conn, err := net.Dial("tcp", url)
+	if err != nil {
+		fmt.Printf("error connecting to %s\n", url)
+		return
+	}
+	agent := &Client{}
+	agent.Conn = conn
+	agent.reader = bufio.NewReader(conn)
+	agent.writer = bufio.NewWriter(conn)
+	agent.state = CLIENT_UNLOGGED
+	agent.incomingMessages = make(chan ClientMessage)
+	agent.canTerminate = make(chan string, 1)
+
+	globalState.WaitGroup.Add(1)
+	go handleClient(agent, globalState, gameLogicExit)
+}


### PR DESCRIPTION
This is useful when the agent is to be run on a remote machine with no user at the terminal: the agent can be running as a server rather than having to use ssh to login as the participant.

Can be used together with https://nest.pijul.org/FlorentBecker/serverize to turn a client into a server.